### PR TITLE
Correct bugs in Kummer functions

### DIFF
--- a/Anima/diffusion/mcm/animaNODDICompartment.cxx
+++ b/Anima/diffusion/mcm/animaNODDICompartment.cxx
@@ -50,7 +50,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double coefVal = m_WatsonSHCoefficients[i];
         double sqrtVal = std::sqrt((4.0 * i + 1.0) / (4.0 * M_PI));
         double legendreVal = boost::math::legendre_p(2 * i, innerProd);
-        double kummerVal = anima::KummerFunction(-x, i + 0.5, 2.0 * i + 1.5, false, true);
+        double kummerVal = std::tgamma(i + 0.5) * anima::KummerFunction(-x, i + 0.5, 2.0 * i + 1.5) / std::tgamma(2.0 * i + 1.5);
         double xPowVal = std::pow(-x, (double)i);
         double cVal = xPowVal * kummerVal;
         
@@ -64,7 +64,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double cDerivVal = 0.0;
         if (m_EstimateAxialDiffusivity)
         {
-            cDerivVal = -xPowVal * anima::KummerFunction(-x, i + 1.5, 2.0 * i + 2.5, false, true);
+            cDerivVal = - xPowVal * kummerVal;
             if (i > 0)
                 cDerivVal += xPowVal * i * kummerVal / x;
         }

--- a/Anima/diffusion/mcm/animaNODDICompartment.cxx
+++ b/Anima/diffusion/mcm/animaNODDICompartment.cxx
@@ -50,7 +50,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double coefVal = m_WatsonSHCoefficients[i];
         double sqrtVal = std::sqrt((4.0 * i + 1.0) / (4.0 * M_PI));
         double legendreVal = boost::math::legendre_p(2 * i, innerProd);
-        double kummerVal = anima::KummerFunction(-x, i + 0.5, 2.0 * i + 1.5) * std::tgamma(i + 0.5) / std::tgamma(2.0 * i + 1.5);
+        double kummerVal = anima::GetKummerFunctionValue(-x, i + 0.5, 2.0 * i + 1.5) * std::tgamma(i + 0.5) / std::tgamma(2.0 * i + 1.5);
         double xPowVal = std::pow(-x, (double)i);
         double cVal = xPowVal * kummerVal;
         
@@ -64,7 +64,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double cDerivVal = 0.0;
         if (m_EstimateAxialDiffusivity)
         {
-            cDerivVal = -xPowVal * anima::KummerFunction(-x, i + 1.5, 2.0 * i + 2.5) * std::tgamma(i + 1.5) / std::tgamma(2.0 * i + 2.5);
+            cDerivVal = -xPowVal * anima::GetKummerFunctionValue(-x, i + 1.5, 2.0 * i + 2.5) * std::tgamma(i + 1.5) / std::tgamma(2.0 * i + 2.5);
             if (i > 0)
                 cDerivVal += xPowVal * i * kummerVal / x;
         }

--- a/Anima/diffusion/mcm/animaNODDICompartment.cxx
+++ b/Anima/diffusion/mcm/animaNODDICompartment.cxx
@@ -50,7 +50,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double coefVal = m_WatsonSHCoefficients[i];
         double sqrtVal = std::sqrt((4.0 * i + 1.0) / (4.0 * M_PI));
         double legendreVal = boost::math::legendre_p(2 * i, innerProd);
-        double kummerVal = std::tgamma(i + 0.5) * anima::KummerFunction(-x, i + 0.5, 2.0 * i + 1.5) / std::tgamma(2.0 * i + 1.5);
+        double kummerVal = anima::KummerFunction(-x, i + 0.5, 2.0 * i + 1.5) * std::tgamma(i + 0.5) / std::tgamma(2.0 * i + 1.5);
         double xPowVal = std::pow(-x, (double)i);
         double cVal = xPowVal * kummerVal;
         
@@ -64,7 +64,7 @@ void NODDICompartment::UpdateSignals(double bValue, const Vector3DType &gradient
         double cDerivVal = 0.0;
         if (m_EstimateAxialDiffusivity)
         {
-            cDerivVal = - xPowVal * kummerVal;
+            cDerivVal = -xPowVal * anima::KummerFunction(-x, i + 1.5, 2.0 * i + 2.5) * std::tgamma(i + 1.5) / std::tgamma(2.0 * i + 2.5);
             if (i > 0)
                 cDerivVal += xPowVal * i * kummerVal / x;
         }

--- a/Anima/diffusion/mcm/animaNODDICompartment.cxx
+++ b/Anima/diffusion/mcm/animaNODDICompartment.cxx
@@ -101,6 +101,8 @@ double NODDICompartment::GetFourierTransformedDiffusionProfile(double smallDelta
     
 NODDICompartment::ListType &NODDICompartment::GetSignalAttenuationJacobian(double smallDelta, double bigDelta, double gradientStrength, const Vector3DType &gradient)
 {
+    itkExceptionMacro("As of now, derivative is not functional for NODDI, please use bobyqa optimizer");
+
     double bValue = anima::GetBValueFromAcquisitionParameters(smallDelta, bigDelta, gradientStrength);
     this->UpdateSignals(bValue, gradient);
     

--- a/Anima/filtering/noise_generator/animaNoiseGenerator.cxx
+++ b/Anima/filtering/noise_generator/animaNoiseGenerator.cxx
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     // Compute mean and variance from Rice distribution
     double snrValue = meanReferenceValue / riceSigmaParameter;
     double laguerreArgument = -1.0 * snrValue * snrValue / 2.0;
-    double laguerreValue = anima::KummerFunction(laguerreArgument, -0.5, 1.0);
+    double laguerreValue = anima::GetKummerFunctionValue(laguerreArgument, -0.5, 1.0);
     double riceMeanValue = riceSigmaParameter * std::sqrt(M_PI / 2.0) * laguerreValue;
     double riceStdValue = 2.0 * riceSigmaParameter * riceSigmaParameter + meanReferenceValue * meanReferenceValue - M_PI * riceSigmaParameter * riceSigmaParameter * laguerreValue * laguerreValue / 2.0;
     if (riceStdValue < 0.0)

--- a/Anima/math-tools/special_functions/animaKummerFunctions.cxx
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.cxx
@@ -104,13 +104,15 @@ double KummerIntegrandMethod(const double &x, const double &a, const double &b)
     integrand.SetBValue(b);
     double resVal = boost::math::quadrature::gauss<double, 15>::integrate(integrand, 0.0, 1.0);
     resVal *= std::tgamma(b) / std::tgamma(a) / std::tgamma(b - a);
+
+    return resVal;
 }
 
 double
 GetKummerFunctionValue(const double &x, const double &a, const double &b,
                        const unsigned int maxIter, const double tol)
 {
-    if ((a == 0)|| (x == 0))
+    if ((a == 0) || (x == 0))
         return 1.0;
 
     if (a == b)
@@ -118,7 +120,7 @@ GetKummerFunctionValue(const double &x, const double &a, const double &b,
 
     if (a > 0 && b > a)
     {
-        double resVal = KummerIntegrandMethod(x,a,b);
+        double resVal = KummerIntegrandMethod(x, a, b);
 
         if (x > 0)
             resVal = std::exp(x + std::log(resVal));
@@ -128,7 +130,7 @@ GetKummerFunctionValue(const double &x, const double &a, const double &b,
 
     double rFactor = std::abs(x * a / b);
     if (rFactor < 20.0)
-        return KummerMethod1(x,a,b,maxIter,tol);
+        return KummerMethod1(x, a, b, maxIter, tol);
     else
     {
         if (a > b)
@@ -140,11 +142,11 @@ GetKummerFunctionValue(const double &x, const double &a, const double &b,
 
             double tmpVal = KummerMethod2(xp,ap,b,maxIter,tol);
             double logResVal = x + std::log(std::abs(tmpVal));
-            double factor = (0 < tmpVal) - (0 > tmpVal);
+            double factor = (0.0 < tmpVal) - (0.0 > tmpVal);
             return factor * std::exp(logResVal);
         }
 
-        return KummerMethod2(x,a,b,maxIter,tol);
+        return KummerMethod2(x, a, b, maxIter, tol);
     }
 }
 
@@ -152,7 +154,7 @@ double
 GetScaledKummerFunctionValue(const double &x, const double &a, const double &b,
                              const unsigned int maxIter, const double tol)
 {
-    if ((a == 0)|| (x == 0))
+    if ((a == 0) || (x == 0))
         return std::exp(-x);
 
     if (a == b)
@@ -160,7 +162,7 @@ GetScaledKummerFunctionValue(const double &x, const double &a, const double &b,
 
     if (a > 0 && b > a)
     {
-        double resVal = KummerIntegrandMethod(x,a,b);
+        double resVal = KummerIntegrandMethod(x, a, b);
 
         if (x < 0)
             resVal = std::exp(- x + std::log(resVal));
@@ -170,7 +172,7 @@ GetScaledKummerFunctionValue(const double &x, const double &a, const double &b,
 
     double rFactor = std::abs(x * a / b);
     if (rFactor < 20.0)
-        return std::exp(-x + std::log(KummerMethod1(x,a,b,maxIter,tol)));
+        return std::exp(-x + std::log(KummerMethod1(x, a, b, maxIter, tol)));
     else
     {
         if (a > b)
@@ -180,13 +182,10 @@ GetScaledKummerFunctionValue(const double &x, const double &a, const double &b,
             if (ap > b)
                 throw itk::ExceptionObject(__FILE__, __LINE__,"Invalid inputs for Kummer function using method 2",ITK_LOCATION);
 
-            double tmpVal = KummerMethod2(xp,ap,b,maxIter,tol);
-            double logResVal = std::log(std::abs(tmpVal));
-            double factor = (0 < tmpVal) - (0 > tmpVal);
-            return factor * std::exp(logResVal);
+            return KummerMethod2(xp, ap, b, maxIter, tol);
         }
 
-        return std::exp(-x + std::log(KummerMethod2(x,a,b,maxIter,tol)));
+        return std::exp(-x + std::log(KummerMethod2(x, a, b, maxIter, tol)));
     }
 }
 

--- a/Anima/math-tools/special_functions/animaKummerFunctions.cxx
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.cxx
@@ -123,6 +123,10 @@ KummerFunction(const double &x,
         integrand.SetBValue(b);
         double resVal = boost::math::quadrature::gauss<double, 15>::integrate(integrand, 0.0, 1.0);
         resVal *= std::tgamma(b) / std::tgamma(a) / std::tgamma(b - a);
+
+        if (x > 0)
+            resVal = std::exp(x + std::log(resVal));
+
         return resVal;
     }
 

--- a/Anima/math-tools/special_functions/animaKummerFunctions.cxx
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.cxx
@@ -109,6 +109,12 @@ KummerFunction(const double &x,
                const unsigned int maxIter,
                const double tol)
 {
+    if ((a == 0)|| (x == 0))
+        return 1.0;
+
+    if (a == b)
+        return std::exp(x);
+
     if (a > 0 && b > a)
     {
         KummerIntegrand integrand;

--- a/Anima/math-tools/special_functions/animaKummerFunctions.h
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.h
@@ -10,14 +10,14 @@ ANIMASPECIALFUNCTIONS_EXPORT
 double PochHammer(const double &x,
                   const unsigned int n);
 
-//! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method 1, p.5
+//! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method 1.C, p.5
 ANIMASPECIALFUNCTIONS_EXPORT
 double
 KummerMethod1(const double &x,
               const double &a,
               const double &b,
-              const unsigned int maxIter = 10000,
-              const double tol = 1.0e-15);
+              const unsigned int maxIter = 1000,
+              const double tol = 1.0e-8);
 
 //! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method 2, p.6
 ANIMASPECIALFUNCTIONS_EXPORT
@@ -25,8 +25,8 @@ double
 KummerMethod2(const double &x,
               const double &a,
               const double &b,
-              const unsigned int maxIter = 10000,
-              const double tol = 1.0e-15);
+              const unsigned int maxIter = 1000,
+              const double tol = 1.0e-8);
 
 //! Computes the confluent hypergeometric function 1F1 also known as the Kummer function M because it is the solution of Kummer's equation. This code implements some of the methods from Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. It switches between Method 1 and 2 according to recommendation at the end of page 5. Covers most situations (at least all common situations encountered in MR image processing).
 ANIMASPECIALFUNCTIONS_EXPORT
@@ -34,10 +34,8 @@ double
 KummerFunction(const double &x,
                const double &a,
                const double &b,
-               const bool scaled = false,
-               const bool normalized = false,
-               const unsigned int maxIter = 10000,
-               const double tol = 1.0e-15);
+               const unsigned int maxIter = 1000,
+               const double tol = 1.0e-8);
 
 class KummerIntegrand
 {
@@ -48,7 +46,7 @@ public:
     
     double operator() (const double t)
     {
-        return std::exp(m_XValue * (t - (double)(m_XValue > 0))) * std::pow(t, m_AValue - 1.0) * std::pow(1.0 - t, m_BValue - m_AValue - 1.0);
+        return std::exp(m_XValue * t) * std::pow(t, m_AValue - 1.0) * std::pow(1.0 - t, m_BValue - m_AValue - 1.0);
     }
     
 private:

--- a/Anima/math-tools/special_functions/animaKummerFunctions.h
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.h
@@ -46,7 +46,9 @@ public:
     
     double operator() (const double t)
     {
-        return std::exp(m_XValue * t) * std::pow(t, m_AValue - 1.0) * std::pow(1.0 - t, m_BValue - m_AValue - 1.0);
+        // For better numerical stability
+        double tModified = t - (m_XValue > 0);
+        return std::exp(m_XValue * tModified) * std::pow(t, m_AValue - 1.0) * std::pow(1.0 - t, m_BValue - m_AValue - 1.0);
     }
     
 private:

--- a/Anima/math-tools/special_functions/animaKummerFunctions.h
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.h
@@ -49,7 +49,7 @@ public:
     double operator() (const double t)
     {
         // For better numerical stability
-        double tModified = t - (m_XValue > 0);
+        double tModified = t - (m_XValue > 0.0);
         return std::exp(m_XValue * tModified) * std::pow(t, m_AValue - 1.0) * std::pow(1.0 - t, m_BValue - m_AValue - 1.0);
     }
     

--- a/Anima/math-tools/special_functions/animaKummerFunctions.h
+++ b/Anima/math-tools/special_functions/animaKummerFunctions.h
@@ -13,29 +13,31 @@ double PochHammer(const double &x,
 //! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method 1.C, p.5
 ANIMASPECIALFUNCTIONS_EXPORT
 double
-KummerMethod1(const double &x,
-              const double &a,
-              const double &b,
-              const unsigned int maxIter = 1000,
-              const double tol = 1.0e-8);
+KummerMethod1(const double &x, const double &a, const double &b,
+              const unsigned int maxIter = 1000, const double tol = 1.0e-8);
 
 //! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method 2, p.6
 ANIMASPECIALFUNCTIONS_EXPORT
 double
-KummerMethod2(const double &x,
-              const double &a,
-              const double &b,
-              const unsigned int maxIter = 1000,
-              const double tol = 1.0e-8);
+KummerMethod2(const double &x, const double &a, const double &b,
+              const unsigned int maxIter = 1000, const double tol = 1.0e-8);
 
-//! Computes the confluent hypergeometric function 1F1 also known as the Kummer function M because it is the solution of Kummer's equation. This code implements some of the methods from Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. It switches between Method 1 and 2 according to recommendation at the end of page 5. Covers most situations (at least all common situations encountered in MR image processing).
+//! According to Muller, K. E. (2001) ‘Computing the confluent hypergeometric function, M (a, b, x)’, Numerische Mathematik, pp. 179–196. Method with integral if b > a > 0
 ANIMASPECIALFUNCTIONS_EXPORT
 double
-KummerFunction(const double &x,
-               const double &a,
-               const double &b,
-               const unsigned int maxIter = 1000,
-               const double tol = 1.0e-8);
+KummerIntegrandMethod(const double &x, const double &a, const double &b);
+
+//! Computes the confluent hypergeometric function 1F1 also known as the Kummer function M. It calls Kummer function core to get the value.
+ANIMASPECIALFUNCTIONS_EXPORT
+double
+GetKummerFunctionValue(const double &x, const double &a, const double &b,
+                       const unsigned int maxIter = 1000, const double tol = 1.0e-8);
+
+//! Computes the confluent hypergeometric function 1F1 also known as the Kummer function M. It returns a scaled value: exp(-x) * M(x,a,b).
+ANIMASPECIALFUNCTIONS_EXPORT
+double
+GetScaledKummerFunctionValue(const double &x, const double &a, const double &b,
+                             const unsigned int maxIter = 1000, const double tol = 1.0e-8);
 
 class KummerIntegrand
 {


### PR DESCRIPTION
Removes some bugs in implementations. But mainly uses method 1.C of Muller article rather than method 1. Much more stable.