### PR TITLE
fix error message when 0 label in input image 

### DIFF
--- a/Anima/segmentation/validation_tools/segmentation_performance_analyzer/animaSegPerfCAnalyzer.cxx
+++ b/Anima/segmentation/validation_tools/segmentation_performance_analyzer/animaSegPerfCAnalyzer.cxx
@@ -393,14 +393,14 @@ void SegPerfCAnalyzer::checkNumberOfLabels(int iNbLabelsImageTest, int iNbLabels
     if(iNbLabelsImageTest<=1)
     {
         m_uiNbLabels = 1;
-        std::cerr << "ERROR : Number of labels for ground truth is 0 !" << std::endl;
+        std::cerr << "ERROR : Number of labels in input image is 0 !" << std::endl;
         return;
     }
 
     if(iNbLabelsImageRef<=1)
     {
         m_uiNbLabels = 1;
-        std::cerr << "ERROR : Number of labels for reference image is 0 !"<< std::endl;
+        std::cerr << "ERROR : Number of labels in ground truth is 0 !"<< std::endl;
         return;
     }
 


### PR DESCRIPTION
The message was:

> Number of labels for ground truth is 0 !

instead of 

> Number of labels in input image is 0 !