### PR TITLE
Improve detection of bash executable on Windows platforms.

### DIFF
--- a/superbuild/CheckEnvironment.cmake
+++ b/superbuild/CheckEnvironment.cmake
@@ -12,6 +12,12 @@ if (WIN32)
   # GitBash
   find_program(BASH_BIN NAMES bash)
   if (NOT BASH_BIN)
+    if(EXISTS $ENV{ProgramFiles}/Git/git-bash.exe)
+      set(BASH_BIN "$ENV{ProgramFiles}/Git/git-bash.exe" CACHE FILEPATH "Path to git bash program" FORCE)
+    endif()
+  endif()
+
+  if (NOT BASH_BIN)
     message( SEND_ERROR 
       "You need to install GitBash and add it to the PATH environment variable." 
       )

--- a/superbuild/CheckEnvironment.cmake
+++ b/superbuild/CheckEnvironment.cmake
@@ -7,36 +7,23 @@ set(HOME_PATH $ENV{HOME})
 ## #############################################################################
 ## Look for windows specific programs
 ## #############################################################################
-
 if (WIN32)
   # GitBash
-  find_program(BASH_BIN NAMES bash)
-  if (NOT BASH_BIN)
-    if(EXISTS $ENV{ProgramFiles}/Git/git-bash.exe)
-      set(BASH_BIN "$ENV{ProgramFiles}/Git/git-bash.exe" CACHE FILEPATH "Path to git bash program" FORCE)
-    endif()
-  endif()
-
-  if (NOT BASH_BIN)
-    message( SEND_ERROR 
-      "You need to install GitBash and add it to the PATH environment variable." 
-      )
+  find_program(BASH_BIN NAMES git-bash bash PATHS "$ENV{ProgramFiles}/Git/")
+  if (NOT BASH_BIN) #TODO for future replace by Required into find_program
+    message(SEND_ERROR "You need to install GitBash and add it to the PATH environment variable.")
   else()
-      mark_as_advanced(BASH_BIN)
+    mark_as_advanced(BASH_BIN)
   endif()
-
   set(HOME_PATH $ENV{HOMEDRIVE}$ENV{HOMEPATH})
 endif()
-
 
 ## #############################################################################
 ## Look for Git
 ## #############################################################################
 find_program(GIT_BIN NAMES git)
 if (NOT GIT_BIN)
-  message(SEND_ERROR 
-    "You need to install Git and add it to the PATH environment variable." 
-    )
+  message(SEND_ERROR "You need to install Git and add it to the PATH environment variable.")
 else()
   mark_as_advanced(GIT_BIN)
 endif()
@@ -44,12 +31,9 @@ endif()
 ## #############################################################################
 ## Look for SSH
 ## #############################################################################
-
 find_program(SSH_BIN NAMES ssh)
 if (NOT SSH_BIN)
-  message(SEND_ERROR 
-    "You need to install SSH and add it to the PATH environment variable."
-    )
+  message(SEND_ERROR "You need to install SSH and add it to the PATH environment variable.")
 else()
   mark_as_advanced(SSH_BIN)
 endif()
@@ -57,10 +41,7 @@ endif()
 ## #############################################################################
 ## Test ssh access for github
 ## #############################################################################
-
-set (SKIP_GITHUB_TESTS OFF CACHE BOOL 
-  "Set this to ON to skip GitHub access tests"
-  )
+set (SKIP_GITHUB_TESTS OFF CACHE BOOL "Set this to ON to skip GitHub access tests")
 mark_as_advanced(SKIP_GITHUB_TESTS)
 
 if (NOT ${SKIP_GITHUB_TESTS} AND ${USE_GITHUB_SSH})


### PR DESCRIPTION
This PR copies the behavior of [medInria ](https://github.com/medInria/medInria-public/blob/master/superbuild/external_projects_tools/EP_CheckEnvironment.cmake) about bash on Windows.

If you don't install the standalone Win32 OpenSSH you will not have bash.exe, but with git's installation, you already have git-bash.exe
It's highly recommended to use native OpenSSH of _Windows 10_ rather than standalone OpenSSH package.
Furthermore, just calling "bash" without extension on a Win10 with installed [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) calls the bash of your Linux and that is not what you want :)

This modification is **very important** for compilation of anima's plugin on **medInria CI** (Win10).
